### PR TITLE
add --sort arg to cmd purgo to make it sort and save

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,7 +53,10 @@ pub enum Commands {
     Glance,
 
     /// -> purge all the duplicated lines
-    Purge, // no alias for safe
+    Purge {
+        #[arg(short, long)]
+        sort: bool,
+    }, // no alias for safe
 
     /// -> sink all outdated uncompeleted to "today"
     Sink {

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,13 +119,13 @@ fn main() {
             TaskBox::list_boxes(inbox_path)
         }
 
-        Some(Commands::Purge) => {
+        Some(Commands::Purge { sort }) => {
             if inquire::Confirm::new("are you sure?")
                 .with_default(false)
                 .prompt().unwrap_or(false) {
 
                 let mut todo = TaskBox::new(inbox_path);
-                todo.purge();
+                todo.purge(sort);
             }
         }
 

--- a/src/taskbox.rs
+++ b/src/taskbox.rs
@@ -194,7 +194,7 @@ impl TaskBox {
         self._dump();
     }
 
-    pub fn purge(&mut self) {
+    pub fn purge(&mut self, sort: bool) {
         use std::collections::HashSet;
 
         self._load();
@@ -222,6 +222,9 @@ impl TaskBox {
                 *done = false
             }
         }
+
+        // (optional) 3rd scan: sort by completed and uncomplated
+        if sort { newtasks.sort_by(|a, b| a.1.cmp(&b.1)) }
 
         self.tasks = newtasks;
         self._dump();


### PR DESCRIPTION
only to sort the "uncompleted" and "completed"
no str literal sorting, to keep the original order at most