### PR TITLE
Enhance cmd edit to add --with arg to enable side-by-side editing

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,7 +42,11 @@ pub enum Commands {
 
     /// -> edit todo inbox file
     #[clap(visible_aliases(["e", "ed"]))]
-    Edit,
+    Edit {
+        #[arg(short, long)]
+        #[arg(value_name = "another-taskbox")]
+        with: Option<String>,
+    },
 
     /// -> count items in inbox
     #[clap(visible_aliases(["c"]))]
@@ -70,6 +74,7 @@ pub enum Commands {
     /// -> collect all uncompeleted in INBOX(or --inbox <which>) to "today"
     Collect {
         #[arg(short, long)]
+        #[arg(value_name = "taskbox-name")]
         inbox: Option<String>,
     },
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,10 +97,10 @@ fn main() {
             execute!(io::stdout(), DefaultUserShape).expect("failed to set cursor");
         }
 
-        Some(Commands::Edit) => {
+        Some(Commands::Edit { with }) => {
             let _todo = TaskBox::new(inbox_path.clone()); // then do nothing, to create the file if it doesn't exist
 
-            util::edit_box(&inbox_path);
+            util::edit_box(&inbox_path, with);
         }
 
         Some(Commands::Count) => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,7 +19,12 @@ pub fn edit_box(inbox_path: &Path, with: Option<String>) {
     let editor = env::var("EDITOR").unwrap_or("vi".to_string());
 
     if let Some(other) = with {
-        let otherf = format!("{}/{}.md", inbox_path.parent().unwrap().display(), &other);
+        let otherf = if other.ends_with(".md") {
+            &other
+        } else {
+            &format!("{}/{}.md", inbox_path.parent().unwrap().display(), &other)
+        };
+
         println!("editing : {} v.s. {}", inbox_path.display().to_string().purple(), other.red());
         run_cmd!(
             vimdiff $inbox_path $otherf 2>/dev/null

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,10 +15,20 @@ pub fn glance_all(inbox_path: &Path) {
     println!("{}", &res[6..])
 }
 
-pub fn edit_box(inbox_path: &Path) {
+pub fn edit_box(inbox_path: &Path, with: Option<String>) {
     let editor = env::var("EDITOR").unwrap_or("vi".to_string());
-    println!("editing : {}", inbox_path.display().to_string().purple());
-    run_cmd!(
-        $editor $inbox_path 2>/dev/null
-    ).expect("cannot launch cli editor(vi?)")
+
+    if let Some(other) = with {
+        let otherf = format!("{}/{}.md", inbox_path.parent().unwrap().display(), &other);
+        println!("editing : {} v.s. {}", inbox_path.display().to_string().purple(), other.red());
+        run_cmd!(
+            vimdiff $inbox_path $otherf 2>/dev/null
+        ).expect("cannot launch vimdiff")
+
+    } else {
+        println!("editing : {}", inbox_path.display().to_string().purple());
+        run_cmd!(
+            $editor $inbox_path 2>/dev/null
+        ).expect("cannot launch cli editor(vi?)")
+    }
 }


### PR DESCRIPTION
The optional "--with <another-taskbox>" can accept both task-name in current basedir and the path of a md file.