### PR TITLE
Sub tasks support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
     match args.command {
         Some(Commands::Mark) | None => {
             let mut todo = TaskBox::new(inbox_path);
-            let (tasks,_) = todo._list();
+            let (tasks,_) = todo._get_all();
             if tasks.is_empty() {
                 println!(" {} left!", "nothing".yellow());
                 return
@@ -52,22 +52,7 @@ fn main() {
 
         Some(Commands::List { all }) => {
             let mut todo = TaskBox::new(inbox_path);
-            let (tasks, dones) = todo._list();
-
-            if tasks.is_empty() {
-                println!(" {} left!", "nothing".yellow());
-            } else {
-                for t in tasks {
-                    println!("{}  {}", "󰄗".blink().blue(), t)
-                }
-            }
-
-            if all && !dones.is_empty() {
-                println!();
-                for t in dones {
-                    println!("{}  {}", "󰄲".green(), t.strikethrough())
-                }
-            }
+            todo.list(all);
         }
 
         Some(Commands::Add { what, date }) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,14 +58,14 @@ fn main() {
                 println!(" {} left!", "nothing".yellow());
             } else {
                 for t in tasks {
-                    println!("{}  {}", "󰄗".blink().green(), t)
+                    println!("{}  {}", "󰄗".blink().blue(), t)
                 }
             }
 
             if all && !dones.is_empty() {
                 println!();
                 for t in dones {
-                    println!("󰄲  {}", t.strikethrough())
+                    println!("{}  {}", "󰄲".green(), t.strikethrough())
                 }
             }
         }

--- a/src/taskbox.rs
+++ b/src/taskbox.rs
@@ -259,7 +259,7 @@ impl TaskBox {
 
         // 1st scan: remove dups
         for (task, done) in self.tasks.iter() {
-            if ! hs.contains(task) {
+            if ! hs.contains(task) || task.starts_with(SUB_PREFIX) {
                 newtasks.push((task.clone(), *done));
                 hs.insert(task);
             }


### PR DESCRIPTION
# Very basic sub-tasks support

Usage: mark tasks as sub-tasks by editing the md file manually, below are the summary of how commands changes along with sub-tasks:

- enhanced: list
- compatibile: add, mark, purge, count
- not affected: listbox, edit, glance
- careful: 4 bigs, import, purge --sort