### PR TITLE
Sub tasks supporting enhancements

### DIFF
--- a/src/taskbox.rs
+++ b/src/taskbox.rs
@@ -271,7 +271,7 @@ impl TaskBox {
 
         // 1st scan: remove dups
         for (task, done) in self.tasks.iter() {
-            if ! hs.contains(task) || task.starts_with(SUB_PREFIX) {
+            if ! hs.contains(task) {
                 newtasks.push((task.clone(), *done));
                 hs.insert(task);
             }

--- a/src/taskbox.rs
+++ b/src/taskbox.rs
@@ -189,6 +189,13 @@ impl TaskBox {
     pub fn list(&mut self, listall: bool) {
         let (tasks, dones) = self._get_all();
 
+        if listall && !dones.is_empty() {
+            for t in dones {
+                println!("{}  {}", "󰄲".green(), t.strikethrough())
+            }
+            println!();
+        }
+
         if tasks.is_empty() {
             println!(" {} left!", "nothing".yellow());
         } else {
@@ -209,13 +216,6 @@ impl TaskBox {
                     msg = msg + &t;
                 }
                 println!("{}", msg);
-            }
-        }
-
-        if listall && !dones.is_empty() {
-            println!();
-            for t in dones {
-                println!("{}  {}", "󰄲".green(), t.strikethrough())
             }
         }
     }
@@ -272,7 +272,8 @@ impl TaskBox {
         }
 
         // (optional) 3rd scan: sort by completed and uncomplated
-        if sort { newtasks.sort_by(|a, b| a.1.cmp(&b.1)) }
+        // upper: completed
+        if sort { newtasks.sort_by(|a, b| b.1.cmp(&a.1)) }
 
         self.tasks = newtasks;
         self._dump();


### PR DESCRIPTION
Hack way to make `mark` and `purge` commands work well with sub-tasks.

By appending different length of spaces to the sub-tasks.