### PR TITLE
Windows support added

### DIFF
--- a/src/taskbox.rs
+++ b/src/taskbox.rs
@@ -17,7 +17,7 @@ pub fn get_inbox_file(dir: Option<String>, inbox: Option<String>) -> PathBuf {
     let base_path = dir.map(PathBuf::from).unwrap_or_else(|| {
         dirs::home_dir()
             .expect("cannot get home directory")
-            .join(DATA_BASE)
+            .join(Path::new(DATA_BASE))
     });
     fs::create_dir_all(&base_path).expect("Failed to create base directory");
 

--- a/src/taskbox.rs
+++ b/src/taskbox.rs
@@ -21,7 +21,14 @@ pub fn get_inbox_file(dir: Option<String>, inbox: Option<String>) -> PathBuf {
     });
     fs::create_dir_all(&base_path).expect("Failed to create base directory");
 
-    base_path.join(inbox.unwrap_or(INBOX_NAME.to_string())).with_extension("md")
+    let inbox_name = match inbox.as_deref() {
+        Some("today") => get_today(),
+        Some("tomorrow") => get_tomorrow(),
+        Some("yesterday") => get_yesterday(),
+        None => INBOX_NAME.to_string(),
+        _ => inbox.unwrap(),
+    };
+    base_path.join(inbox_name).with_extension("md")
 }
 
 pub fn get_today() -> String {


### PR DESCRIPTION
1. will call "notepad" for edit command
2. will ignore "glance" subcommands, because it is too Unix oriented
3. make --inbox opt to accept "today/tomorrow" alias name, get easier for windows users
4. to release windows binaries by GHA