### PR TITLE
Interactive mode support for sink/shift/pool/collect moving commands

### DIFF
--- a/src/boxops.rs
+++ b/src/boxops.rs
@@ -124,7 +124,7 @@ pub fn cleanup() -> Result<()> {
                 println!()
             }
         });
-    if util::confirm("Going to remove the aboves, are you sure?") {
+    if util::i_confirm("Going to remove the aboves, are you sure?") {
         boxes.into_iter().for_each(
             |(_, path)| {
                 std::fs::remove_file(&path).expect("cannot remove file");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -100,11 +100,15 @@ pub enum Commands {
     /// -> shift all uncompeleted in "today" to "tomorrow"
     Shift,
 
-    /// -> collect all uncompeleted in INBOX(or --inbox <which>) to "today"
+    /// -> collect all uncompeleted in INBOX(or --boxname <?>) to "today"
     Collect {
         #[arg(short, long)]
-        #[arg(value_name = "taskbox-name")]
-        inbox: Option<String>,
+        #[arg(value_name = "task-box-name")]
+        boxname: Option<String>,
+
+        /// interactive mode to select items to move
+        #[arg(short, long)]
+        interactive: bool,
     },
 
     /// -> pooling all uncompeleted of today to INBOX

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,9 +93,6 @@ pub enum Commands {
 
     /// -> sink all outdated uncompeleted to "today"
     Sink {
-        #[arg(short, long)]
-        all: bool,
-
         /// interactive mode to select items to move
         #[arg(short, long)]
         interactive: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -95,10 +95,18 @@ pub enum Commands {
     Sink {
         #[arg(short, long)]
         all: bool,
+
+        /// interactive mode to select items to move
+        #[arg(short, long)]
+        interactive: bool,
     },
 
     /// -> shift all uncompeleted in "today" to "tomorrow"
-    Shift,
+    Shift {
+        /// interactive mode to select items to move
+        #[arg(short, long)]
+        interactive: bool,
+    },
 
     /// -> collect all uncompeleted in INBOX(or --boxname <?>) to "today"
     Collect {
@@ -112,7 +120,11 @@ pub enum Commands {
     },
 
     /// -> pooling all uncompeleted of today to INBOX
-    Pool,
+    Pool {
+        /// interactive mode to select items to move
+        #[arg(short, long)]
+        interactive: bool,
+    },
 
     /// -> import uncompeleted task in any markdown file to current
     Import{

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,12 @@ fn main() {
     match args.command {
         Some(Commands::List) | None       => TaskBox::new(inbox_path).list(false),
         Some(Commands::Listall)           => TaskBox::new(inbox_path).list(true),
-        Some(Commands::Count)             => TaskBox::new(inbox_path).count(),
+
+        Some(Commands::Count)             => {
+            let cc = TaskBox::new(inbox_path).count();
+            if cc > 0 { println!("{}", cc) }
+        }
+
         Some(Commands::Import{ file })    => TaskBox::new(inbox_path).import(file),
         Some(Commands::Purge { sort }) => {
             if i_confirm("are you sure?") {
@@ -79,7 +84,7 @@ fn main() {
 
                 if boxdate < today {
                     let mut tb_from = TaskBox::new(taskbox);
-                    //if tb_from.count() == 0 { continue }
+                    if tb_from.count() == 0 { continue }
 
                     if interactive {
                         tb_from.selected = Some(i_select(tb_from.get_all_to_mark(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,10 +79,14 @@ fn main() {
 
                 if boxdate < today {
                     let mut tb_from = TaskBox::new(taskbox);
+                    //if tb_from.count() == 0 { continue }
+
                     if interactive {
-                        tb_from.selected = Some(i_select(tb_from.get_all_to_mark()));
+                        tb_from.selected = Some(i_select(tb_from.get_all_to_mark(),
+                                                &format!("choose from {}", boxdate)));
                     }
-                    tb_today.collect_from(&mut tb_from)
+                    tb_today.collect_from(&mut tb_from);
+                    println!();
                 }
             }
         }
@@ -90,7 +94,7 @@ fn main() {
         Some(Commands::Shift { interactive }) => { // today -> tomorrow
             let mut tb_today = TaskBox::new(util::get_inbox_file("today"));
             if interactive {
-                tb_today.selected = Some(i_select(tb_today.get_all_to_mark()));
+                tb_today.selected = Some(i_select(tb_today.get_all_to_mark(), "choose from TODAY"));
             }
             TaskBox::new(util::get_inbox_file("tomorrow")).collect_from(&mut tb_today)
         }
@@ -98,7 +102,7 @@ fn main() {
         Some(Commands::Pool { interactive }) => { // today -> INBOX
             let mut tb_today = TaskBox::new(util::get_inbox_file("today"));
             if interactive {
-                tb_today.selected = Some(i_select(tb_today.get_all_to_mark()));
+                tb_today.selected = Some(i_select(tb_today.get_all_to_mark(), "choose from TODAY"));
             }
 
             TaskBox::new(util::get_inbox_file("inbox")).collect_from(&mut tb_today)
@@ -114,7 +118,8 @@ fn main() {
             let mut tb_from = TaskBox::new(util::get_inbox_file(&from));
 
             if interactive {
-                tb_from.selected = Some(i_select(tb_from.get_all_to_mark()));
+                tb_from.selected = Some(i_select(tb_from.get_all_to_mark(),
+                                                 &format!("choose from {}", from)));
             }
 
             TaskBox::new(util::get_inbox_file("today")).collect_from(&mut tb_from)
@@ -128,7 +133,7 @@ fn main() {
                 return
             }
 
-            todo.mark(i_select(tasks));
+            todo.mark(i_select(tasks, "choose to close:"));
         }
 
         Some(Commands::Add { what, date_stamp, routine, interactive }) => {
@@ -137,12 +142,12 @@ fn main() {
             }
             let mut todo = TaskBox::new(inbox_path);
 
-            let input = what.unwrap_or(i_text());
+            let input = what.unwrap_or(i_gettext());
             if !input.is_empty() {
                 let mut start_date = get_today();
 
                 if routine.is_some() && interactive {
-                    start_date = i_date(match routine {
+                    start_date = i_getdate(match routine {
                             Some(Routine::Daily)    => "daily",
                             Some(Routine::Weekly)   => "weekly",
                             Some(Routine::Biweekly) => "biweekly",

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,15 +93,16 @@ fn main() {
             }
 
             execute!(io::stdout(), BlinkingBlock).expect("failed to set cursor");
-            let selected = inquire::MultiSelect::new("choose to close:", tasks)
+            let mut selected = inquire::MultiSelect::new("choose to close:", tasks)
                 .with_render_config(get_multi_select_style())
                 .with_vim_mode(true)
                 .with_page_size(10)
                 .with_help_message("j/k | <space> | <enter> | ctrl+c")
                 .prompt().unwrap_or_else(|_| Vec::new());
+                selected.retain(|x| !x.contains(WARN));
             execute!(io::stdout(), DefaultUserShape).expect("failed to set cursor");
 
-            todo.mark(selected);
+            todo.mark(selected)
         }
 
         Some(Commands::Add { what, date_stamp, routine, interactive }) => {

--- a/src/styles.rs
+++ b/src/styles.rs
@@ -36,6 +36,8 @@ macro_rules! S_success { ($e:expr) => { $e.to_string().green().bold() }; }
 #[macro_export]
 macro_rules! S_failure { ($e:expr) => { $e.to_string().red().blink() }; }
 #[macro_export]
+macro_rules! S_warning { ($e:expr) => { $e.to_string().yellow() }; }
+#[macro_export]
 macro_rules! S_routine { ($e:expr) => { $e.to_string().purple().italic() }; }
 #[macro_export]
 macro_rules! S_blink { ($e:expr) => {

--- a/src/taskbox.rs
+++ b/src/taskbox.rs
@@ -388,10 +388,9 @@ impl TaskBox {
         }
     }
 
-    pub fn count(&mut self) {
+    pub fn count(&mut self) -> usize {
         self.load();
-        let cc = self.tasks.iter().filter(|(_, done)| !done).count();
-        if cc > 0 { println!("{}", cc) }
+        self.tasks.iter().filter(|(_, done)| !done).count()
     }
 
     pub fn mark(&mut self, items: Vec<String>) {

--- a/src/taskbox.rs
+++ b/src/taskbox.rs
@@ -221,9 +221,13 @@ impl TaskBox {
                         self.tasks.push(pair)
                     }
                 } else {
-                    eprintln!("  {} : ignore non-routine task: {}",
+                    // ignore non-routine task
+                    println!("{} {} : {} {}",
                             S_failure!(WARN),
-                            S_failure!(task));
+                            S_checkbox!(CHECKBOX),
+                            S_warning!("skip:"),
+                            task);
+                    continue
                 }
 
             } else {
@@ -231,13 +235,17 @@ impl TaskBox {
                 if task.contains(WARN) {
                     println!("  {} : {}", S_checkbox!(CHECKED), task);
                 } else if caps.is_some() {
-                    println!("  {} : unexpected routine task move: {}",
+                    println!("{} {} : {}",
                             S_failure!(WARN),
-                            S_failure!(task));
+                            S_checkbox!(CHECKBOX),
+                            task);
                 } else if RE_ROUTINES_CHECKOUT.is_match(&task) && to == INBOX_NAME {
-                    eprintln!("  {} : ignore checkout routine task: {}",
+                    // ignore checkout routine task
+                    println!("{} {} : {} {}",
                             S_failure!(WARN),
-                            S_failure!(task));
+                            S_checkbox!(CHECKBOX),
+                            S_warning!("skip:"),
+                            task);
                     continue
 
                 } else {

--- a/src/taskbox.rs
+++ b/src/taskbox.rs
@@ -451,17 +451,22 @@ impl TaskBox {
     }
 
     // INBOX -> today
-    pub fn collect(inbox_from: Option<String>) {
-        let from = inbox_from.unwrap_or("inbox".into());
-
-        if from == get_today() || from == "today" {
+    pub fn collect(&mut self, inbox_from: &str, selected: Vec<String>) {
+        // double check
+        if inbox_from == get_today() || inbox_from == "today" {
             println!("{} is not a valid source", S_moveto!("today"));
             return
         }
 
-        TaskBox::new(util::get_inbox_file("today"))
-            .move_in(&mut
-        TaskBox::new(util::get_inbox_file(&from)))
+        self.load();
+        if self.alias != Some("today".to_string()) {
+            println!("collect target is not \"today\", skipped");
+            return
+        }
+
+        println!("{:?}", selected);
+
+        self.move_in(&mut TaskBox::new(util::get_inbox_file(inbox_from)))
     }
 
     // today -> INBOX

--- a/src/taskbox.rs
+++ b/src/taskbox.rs
@@ -34,6 +34,7 @@ pub struct TaskBox {
     pub title: Option<String>,
     pub alias: Option<String>,
     pub tasks: Vec<(String, bool)>,
+    pub selected: Vec<String>,
 }
 
 impl TaskBox {
@@ -42,7 +43,8 @@ impl TaskBox {
             fpath,
             title: None, // None means not loaded
             alias: None,
-            tasks: Vec::new(),
+            tasks: vec![],
+            selected: vec![],
         }
     }
 
@@ -473,7 +475,7 @@ impl TaskBox {
     }
 
     // INBOX -> today
-    pub fn collect(&mut self, inbox_from: &str, selected: Vec<String>) {
+    pub fn collect(&mut self, inbox_from: &str) {
         // double check
         if inbox_from == get_today() || inbox_from == "today" {
             println!("{} is not a valid source", S_moveto!("today"));
@@ -485,8 +487,6 @@ impl TaskBox {
             println!("collect target is not \"today\", skipped");
             return
         }
-
-        println!("{:?}", selected);
 
         self.move_in(&mut TaskBox::new(util::get_inbox_file(inbox_from)))
     }

--- a/src/taskbox.rs
+++ b/src/taskbox.rs
@@ -475,13 +475,6 @@ impl TaskBox {
         }
     }
 
-    // today -> tomorrow
-    pub fn shift() {
-        TaskBox::new(util::get_inbox_file("tomorrow"))
-            .collect_from(&mut
-        TaskBox::new(util::get_inbox_file("today")))
-    }
-
     // specified markdown file -> cur
     pub fn import(&mut self, file: Option<String>) {
         #[allow(clippy::redundant_closure)]

--- a/src/taskbox.rs
+++ b/src/taskbox.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 use std::collections::HashSet;
 use regex::Regex;
 use colored::Colorize;
-use chrono::*;
 use lazy_static::lazy_static;
 
 use crate::cli::*;
@@ -12,7 +11,6 @@ use crate::styles::*;
 use crate::conf::*;
 
 lazy_static! {
-    static ref RE_DATEBOX :Regex = Regex::new(r"\d{4}-\d{2}-\d{2}.md$").unwrap();
     static ref RE_PREFIX_OPEN :Regex = Regex::new(r"^- \[[ ]\] (.*)").unwrap();
     static ref RE_PREFIX_DONE :Regex = Regex::new(r"^- \[[xX\-/<>\*]\] (.*)").unwrap();
     static ref RE_ROUTINES :Regex =
@@ -446,33 +444,6 @@ impl TaskBox {
 
         self.tasks = newtasks;
         self._dump();
-    }
-
-    // outdated -> today
-    // flag:all -- whether sink future (mainly tomorrow)
-    pub fn sink(all: bool) {
-        let basedir = Config_get!("basedir");
-        let mut today_todo = TaskBox::new(util::get_inbox_file("today"));
-
-        let mut boxes = Vec::new();
-        for entry in fs::read_dir(basedir).expect("cannot read dir") {
-            let path = entry.expect("cannot get entry").path();
-            if path.is_file() && RE_DATEBOX.is_match(path.to_str().unwrap()) { 
-                boxes.push(path)
-            }
-        }
-        boxes.sort(); boxes.reverse();
-
-        let today =  Local::now().date_naive();
-        for taskbox in boxes {
-            let boxdate = NaiveDate::parse_from_str(
-                taskbox.file_stem().unwrap().to_str().unwrap(),
-                "%Y-%m-%d").expect("something wrong!");
-
-            if boxdate < today || (all && boxdate != today) {
-                today_todo.collect_from(&mut TaskBox::new(taskbox));
-            }
-        }
     }
 
     // specified markdown file -> cur

--- a/src/util.rs
+++ b/src/util.rs
@@ -135,7 +135,7 @@ pub fn i_select(tasks: Vec<String>, title: &str) -> Vec<String> {
         .with_vim_mode(true)
         .with_page_size(10)
         .with_help_message("h/j/k/l | ←↑↓→ | <space> | <enter> | ctrl+c")
-        .prompt().unwrap_or_else(|_| Vec::new());
+        .prompt().unwrap_or_else(|_| std::process::exit(1));
     execute!(std::io::stdout(), DefaultUserShape).expect("failed to set cursor");
     selected.retain(|x| !x.contains(WARN));
     selected

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,6 +2,9 @@ use std::path::PathBuf;
 use chrono::*;
 use std::ops::*;
 use cmd_lib::*;
+use colored::Colorize;
+use crossterm::execute;
+use crossterm::cursor::SetCursorStyle::*;
 
 pub use crate::*;
 pub use crate::styles::*;
@@ -107,11 +110,45 @@ pub fn get_inbox_file(inbox: &str) -> PathBuf {
     basedir.join(get_box_unalias(inbox)).with_extension("md")
 }
 
-pub fn confirm(question: &str) -> bool {
+pub fn i_confirm(question: &str) -> bool {
     inquire::Confirm::new(question)
         .with_default(false)
         .with_render_config(get_confirm_style())
         .prompt().unwrap_or(false)
+}
+
+pub fn i_text() -> String {
+    execute!(std::io::stdout(), BlinkingBlock).expect("failed to set cursor");
+    let input = inquire::Text::new("")
+            .with_render_config(get_text_input_style())
+            .with_help_message("<enter> | ctrl+c")
+            .with_placeholder("something to do?")
+            .prompt().unwrap_or_else(|_| String::new());
+    execute!(std::io::stdout(), DefaultUserShape).expect("failed to set cursor");
+    input.trim().to_string()
+}
+
+pub fn i_select(tasks: Vec<String>) -> Vec<String> {
+    execute!(std::io::stdout(), BlinkingBlock).expect("failed to set cursor");
+    let mut selected = inquire::MultiSelect::new("choose to close:", tasks)
+        .with_render_config(get_multi_select_style())
+        .with_vim_mode(true)
+        .with_page_size(10)
+        .with_help_message("h/j/k/l | ←↑↓→ | <space> | <enter> | ctrl+c")
+        .prompt().unwrap_or_else(|_| Vec::new());
+    execute!(std::io::stdout(), DefaultUserShape).expect("failed to set cursor");
+    selected.retain(|x| !x.contains(WARN));
+    selected
+}
+
+pub fn i_date(routine_kind: &str) -> String {
+    inquire::DateSelect::new(&format!(" {} from:",S_routine!(routine_kind)))
+        .with_render_config(get_date_input_style())
+        .with_help_message("h/j/k/l | <enter> | ctrl+c")
+        .prompt().unwrap_or_else(|_| {
+                println!("{}", S_empty!("No starting date selected, skip."));
+                std::process::exit(1)
+            }).to_string()
 }
 
 #[cfg(test)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -117,7 +117,7 @@ pub fn i_confirm(question: &str) -> bool {
         .prompt().unwrap_or(false)
 }
 
-pub fn i_text() -> String {
+pub fn i_gettext() -> String {
     execute!(std::io::stdout(), BlinkingBlock).expect("failed to set cursor");
     let input = inquire::Text::new("")
             .with_render_config(get_text_input_style())
@@ -128,9 +128,9 @@ pub fn i_text() -> String {
     input.trim().to_string()
 }
 
-pub fn i_select(tasks: Vec<String>) -> Vec<String> {
+pub fn i_select(tasks: Vec<String>, title: &str) -> Vec<String> {
     execute!(std::io::stdout(), BlinkingBlock).expect("failed to set cursor");
-    let mut selected = inquire::MultiSelect::new("choose to close:", tasks)
+    let mut selected = inquire::MultiSelect::new(title, tasks)
         .with_render_config(get_multi_select_style())
         .with_vim_mode(true)
         .with_page_size(10)
@@ -141,7 +141,7 @@ pub fn i_select(tasks: Vec<String>) -> Vec<String> {
     selected
 }
 
-pub fn i_date(routine_kind: &str) -> String {
+pub fn i_getdate(routine_kind: &str) -> String {
     inquire::DateSelect::new(&format!(" {} from:",S_routine!(routine_kind)))
         .with_render_config(get_date_input_style())
         .with_help_message("h/j/k/l | <enter> | ctrl+c")

--- a/tests/taskbox.rs
+++ b/tests/taskbox.rs
@@ -65,7 +65,7 @@ fn test_purge() {
 }
 
 #[test]
-fn test_move_in_basic() {
+fn test_collect_from_basic() {
     let (mut tb1, _dir1) = setup_test_taskbox("test1");
     let (mut tb2, _dir2) = setup_test_taskbox("test2");
 
@@ -80,7 +80,7 @@ fn test_move_in_basic() {
     tb1.load();
     assert_eq!(tb1.tasks.len(), 3);
 
-    tb2.move_in(&mut tb1);
+    tb2.collect_from(&mut tb1);
 
     tb2.load();
     assert_eq!(tb2.tasks.len(), 2);
@@ -93,7 +93,7 @@ fn test_move_in_basic() {
 }
 
 #[test]
-fn test_move_in_with_warn_msg() {
+fn test_collect_from_with_warn_msg() {
     let (mut tb1, _dir1) = setup_test_taskbox("test1");
     let (mut tb2, _dir2) = setup_test_taskbox("test2");
 
@@ -103,7 +103,7 @@ fn test_move_in_with_warn_msg() {
 
     assert_eq!(tb1.tasks.len(), 2);
 
-    tb2.move_in(&mut tb1);
+    tb2.collect_from(&mut tb1);
     tb2.load();
     assert_eq!(tb2.tasks.len(), 2);
     assert_eq!(tb2.tasks[0].0, "Task to move");
@@ -115,7 +115,7 @@ fn test_move_in_with_warn_msg() {
 }
 
 #[test]
-fn test_move_in_with_sub() {
+fn test_collect_from_with_sub() {
     let (mut tb1, _dir1) = setup_test_taskbox("test1");
     let (mut tb2, _dir2) = setup_test_taskbox("test2");
 
@@ -138,7 +138,7 @@ fn test_move_in_with_sub() {
     tb1.load();
     assert_eq!(tb1.tasks.len(), 2);
 
-    tb2.move_in(&mut tb1);
+    tb2.collect_from(&mut tb1);
 
     let test1_actual = fs::read_to_string(&tb1.fpath).expect("Failed to read tb1 file");
     assert_eq!(test1_output, test1_actual);
@@ -148,7 +148,7 @@ fn test_move_in_with_sub() {
 }
 
 #[test]
-fn test_move_in_with_sub_done() {
+fn test_collect_from_with_sub_done() {
     let (mut tb1, _dir1) = setup_test_taskbox("test1");
     let (mut tb2, _dir2) = setup_test_taskbox("test2");
 
@@ -193,7 +193,7 @@ fn test_move_in_with_sub_done() {
     std::fs::write(&tb1.fpath, test1_input).expect("Failed to write test input to file");
     tb1.load();
 
-    tb2.move_in(&mut tb1);
+    tb2.collect_from(&mut tb1);
 
     let test1_actual = fs::read_to_string(&tb1.fpath).expect("Failed to read tb1 file");
     assert_eq!(test1_output, test1_actual);
@@ -203,7 +203,7 @@ fn test_move_in_with_sub_done() {
 }
 
 #[test]
-fn test_move_in_with_dup_sub() {
+fn test_collect_from_with_dup_sub() {
     let (mut tb1, _dir1) = setup_test_taskbox("test1");
     let (mut tb2, _dir2) = setup_test_taskbox("test2");
 
@@ -248,7 +248,7 @@ fn test_move_in_with_dup_sub() {
     std::fs::write(&tb1.fpath, test1_input).expect("Failed to write test input to file");
     tb1.load();
 
-    tb2.move_in(&mut tb1);
+    tb2.collect_from(&mut tb1);
 
     let test2_actual = fs::read_to_string(&tb2.fpath).expect("Failed to read tb2 file");
     assert_eq!(test2_output, test2_actual);
@@ -282,7 +282,7 @@ fn test_checkout() {
     assert!(routine.tasks[0].0.starts_with("{󰃯:d "));
     assert!(routine.tasks[0].0.ends_with("} Daily routine"));
 
-    today.move_in(&mut routine);
+    today.collect_from(&mut routine);
 
     today.load();
     assert_eq!(today.tasks.len(), 1);
@@ -290,11 +290,11 @@ fn test_checkout() {
     assert!(today.tasks[0].0.contains("} Daily routine"));
     assert!(today.tasks[0].0.contains(" [󰃵 "));
 
-    tb.move_in(&mut routine);
+    tb.collect_from(&mut routine);
     tb.load();
     assert_eq!(tb.tasks.len(), 0);
 
-    today.move_in(&mut routine);
+    today.collect_from(&mut routine);
     today.load();
     assert_eq!(today.tasks.len(), 1);
 }
@@ -323,7 +323,7 @@ fn test_pool_today_to_inbox() {
     assert_eq!(routine.tasks.len(), 1);
 
     // check out
-    today.move_in(&mut routine);
+    today.collect_from(&mut routine);
 
     today.load(); inbox.load(); routine.load();
     assert_eq!(today.tasks.len(), 3);
@@ -331,7 +331,7 @@ fn test_pool_today_to_inbox() {
     assert_eq!(routine.tasks.len(), 1);
 
     // pool
-    inbox.move_in(&mut today);
+    inbox.collect_from(&mut today);
 
     today.load(); inbox.load();
     assert_eq!(today.tasks.len(), 1);

--- a/tests/taskbox.rs
+++ b/tests/taskbox.rs
@@ -15,8 +15,6 @@ fn setup_test_taskbox(name: &str) -> (TaskBox, tempfile::TempDir) {
     let test_conf = Config::load(Some(testtoml.to_str().unwrap().into()));
 
     let mut g_conf = CONFIG.write().unwrap();
-    println!("{:?}", g_conf);
-    println!("{:?}", test_conf);
     g_conf.update_with(&test_conf);
 
     (TaskBox::new(file_path), dir)


### PR DESCRIPTION
Using multi-select inquire component to select which items to be moved for these commands, when --interactive flag used.
Otherwise all open tasks will be moved as before.